### PR TITLE
[sddm] set plasma X11 as the preselected session

### DIFF
--- a/var/lib/sddm/state.conf
+++ b/var/lib/sddm/state.conf
@@ -1,0 +1,3 @@
+[Last]
+# This will manipulate SDDM into setting Plasma as the preselected session
+Session=/usr/share/xsession/plasma.desktop


### PR DESCRIPTION
Per [sddm-state.conf(5)](https://manpages.debian.org/testing/sddm/sddm-state.conf.5.en.html), `state.conf` is the file which stores the last-selected session file path. By shipping a `state.conf` file, we can get SDDM to pre-select the KDE Plasma X11 session (or any other session that will be set as default in the future).

This should fix Nitrux/nitrux-bug-tracker#39